### PR TITLE
Fix channel cover image inconsistency when typing status changed callback called

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.1'
+    buildToolsVersion '27.0.2'
     defaultConfig {
         applicationId "com.sendbird.android.sample"
         minSdkVersion 14

--- a/app/src/main/java/com/sendbird/android/sample/groupchannel/GroupChannelListFragment.java
+++ b/app/src/main/java/com/sendbird/android/sample/groupchannel/GroupChannelListFragment.java
@@ -117,6 +117,7 @@ public class GroupChannelListFragment extends Fragment {
 
             @Override
             public void onTypingStatusUpdated(GroupChannel channel) {
+                mChannelListAdapter.clearMap();
                 mChannelListAdapter.notifyDataSetChanged();
             }
         });


### PR DESCRIPTION
- Images of group channels used to swap when typing status changes for any group in the GroupChannelListFragment